### PR TITLE
Add: Support for sequel and ability to add custom adapter.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    kafka_handle_event (0.0.7)
+    kafka_handle_event (0.0.8)
       activesupport
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.2.1)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,32 @@ Helper to handle kafka events easier
 gem 'kafka_handle_event'
 ```
 
+## Config
+Add `config/initializers/kafka_handle_event.rb`
+```ruby
+KafkaHandleEvent.configure do |config|
+  # default adatper is :active_record
+  config.adapter = :sequel # in case you use sequel instead of active record
+end
+```
+
+Customize default behavior
+```ruby
+# config/initializers/kafka_handle_event.rb
+KafkaHandleEvent::DatabaseAdapter.register :active_record, :create, ->(model_class, attributes) do
+  # do custom logic
+end
+
+KafkaHandleEvent::DatabaseAdapter.register :active_record, :update, ->(model_class, id, attributes) do
+  # do custom logic
+end
+
+KafkaHandleEvent::DatabaseAdapter.register :active_record, :destroy, ->(model_class, id, attributes) do
+  # do custom logic
+end
+
+```
+
 ## Kafka message format
 This lib has its opinion about the message shape it support. The message should have this shape:
 ```json

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "kafka_handle_event",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "documents": [
     {
       "name": "README",

--- a/lib/kafka_handle_event.rb
+++ b/lib/kafka_handle_event.rb
@@ -1,6 +1,7 @@
 require 'kafka_handle_event/config'
 require 'kafka_handle_event/event_proxy'
 require 'kafka_handle_event/event_handler'
+require 'kafka_handle_event/database_adapter'
 require 'active_support/all'
 
 module KafkaHandleEvent
@@ -34,4 +35,38 @@ module KafkaHandleEvent
       end
     end
   end
+end
+
+KafkaHandleEvent::DatabaseAdapter.register :active_record, :create, ->(model_class, attributes) do
+  model_class.create(attributes)
+end
+
+KafkaHandleEvent::DatabaseAdapter.register :active_record, :update, ->(model_class, id, attributes) do
+  record = model_class.find_or_initialize_by(id: id)
+  record.attributes = attributes
+  record.save
+  record
+end
+
+KafkaHandleEvent::DatabaseAdapter.register :active_record, :destroy, ->(model_class, id, attributes) do
+  record = model_class.find_by(id: id)
+  record&.destroy
+  record
+end
+
+KafkaHandleEvent::DatabaseAdapter.register :sequel, :create, ->(model_class, attributes) do
+  model_class.create(attributes)
+end
+
+KafkaHandleEvent::DatabaseAdapter.register :sequel, :update, ->(model_class, id, attributes) do
+  record = model_class.find_or_new(id: id)
+  record.set(attributes)
+  record.save
+  record
+end
+
+KafkaHandleEvent::DatabaseAdapter.register :sequel, :destroy, ->(model_class, id, attributes) do
+  record = model_class.find(id: id)
+  record&.destroy
+  record
 end

--- a/lib/kafka_handle_event/config.rb
+++ b/lib/kafka_handle_event/config.rb
@@ -1,5 +1,11 @@
 module KafkaHandleEvent
   class Config
-    attr_accessor :adapter
+    def adapter
+      @adapter || :active_record
+    end
+
+    def adapter=(adapter)
+      @adapter = adapter
+    end
   end
 end

--- a/lib/kafka_handle_event/config.rb
+++ b/lib/kafka_handle_event/config.rb
@@ -1,4 +1,5 @@
 module KafkaHandleEvent
   class Config
+    attr_accessor :adapter
   end
 end

--- a/lib/kafka_handle_event/database_adapter.rb
+++ b/lib/kafka_handle_event/database_adapter.rb
@@ -1,0 +1,30 @@
+module KafkaHandleEvent
+  class DatabaseAdapter
+    @default_create_blocks = {}
+    @default_update_blocks = {}
+    @default_destroy_blocks = {}
+    VALID_METHOD = [:create, :update, :destroy]
+
+    class << self
+      def register(adapter_name, method, default_block)
+        unless VALID_METHOD.include?(method.to_sym)
+          raise "Method name is not in #{VALID_METHOD.join(', ')}"
+        end
+        default_blocks = instance_variable_get("@default_#{method}_blocks")
+        default_blocks[adapter_name] = default_block
+      end
+
+      def default_create_block(adapter_name)
+        @default_create_blocks[adapter_name]
+      end
+
+      def default_update_block(adapter_name)
+        @default_update_blocks[adapter_name]
+      end
+
+      def default_destroy_block(adapter_name)
+        @default_destroy_blocks[adapter_name]
+      end
+    end
+  end
+end

--- a/lib/kafka_handle_event/event_handler.rb
+++ b/lib/kafka_handle_event/event_handler.rb
@@ -52,13 +52,19 @@ module KafkaHandleEvent
     end
 
     def default_sequel_do_create
+      proxy.model_class.create(mapped_attributes)
     end
 
     def default_activerecord_do_create
-        proxy.model_class.create(mapped_attributes)
+      proxy.model_class.create(mapped_attributes)
     end
 
     def default_sequel_do_update
+      id = mapped_attributes[proxy.primaries[0]]
+      record = proxy.model_class.find_or_new(id: id)
+      record.set(mapped_attributes)
+      record.save
+      record
     end
 
     def default_activerecord_do_update
@@ -78,6 +84,10 @@ module KafkaHandleEvent
     end
 
     def default_sequel_do_destroy
+      id = mapped_attributes[proxy.primaries[0]]
+      record = proxy.model_class.find(id: id)
+      record&.destroy
+      record
     end
 
     def default_activerecord_do_destroy

--- a/lib/kafka_handle_event/event_handler.rb
+++ b/lib/kafka_handle_event/event_handler.rb
@@ -36,65 +36,23 @@ module KafkaHandleEvent
     end
 
     def default_do_create
-      if KafkaHandleEvent.config.adapter == :sequel
-        default_sequel_do_create
-      else
-        default_activerecord_do_create
-      end
+      default_block = KafkaHandleEvent::DatabaseAdapter
+        .default_create_block(KafkaHandleEvent.config.adapter)
+      default_block.call(proxy.model_class, mapped_attributes)
     end
 
     def default_do_update
-      if KafkaHandleEvent.config.adapter == :sequel
-        default_sequel_do_update
-      else
-        default_activerecord_do_update
-      end
-    end
-
-    def default_sequel_do_create
-      proxy.model_class.create(mapped_attributes)
-    end
-
-    def default_activerecord_do_create
-      proxy.model_class.create(mapped_attributes)
-    end
-
-    def default_sequel_do_update
+      default_block = KafkaHandleEvent::DatabaseAdapter
+        .default_update_block(KafkaHandleEvent.config.adapter)
       id = mapped_attributes[proxy.primaries[0]]
-      record = proxy.model_class.find_or_new(id: id)
-      record.set(mapped_attributes)
-      record.save
-      record
-    end
-
-    def default_activerecord_do_update
-      id = mapped_attributes[proxy.primaries[0]]
-      record = proxy.model_class.find_or_initialize_by(id: id)
-      record.attributes = mapped_attributes
-      record.save
-      record
+      default_block.call(proxy.model_class, id, mapped_attributes)
     end
 
     def default_do_destroy
-      if KafkaHandleEvent.config.adapter == :sequel
-        default_sequel_do_destroy
-      else
-        default_activerecord_do_destroy
-      end
-    end
-
-    def default_sequel_do_destroy
+      default_block = KafkaHandleEvent::DatabaseAdapter
+        .default_destroy_block(KafkaHandleEvent.config.adapter)
       id = mapped_attributes[proxy.primaries[0]]
-      record = proxy.model_class.find(id: id)
-      record&.destroy
-      record
-    end
-
-    def default_activerecord_do_destroy
-      id = mapped_attributes[proxy.primaries[0]]
-      record = proxy.model_class.find_by(id: id)
-      record&.destroy
-      record
+      default_block.call(proxy.model_class, id, mapped_attributes)
     end
 
     def mapped_attributes

--- a/lib/kafka_handle_event/event_handler.rb
+++ b/lib/kafka_handle_event/event_handler.rb
@@ -36,10 +36,32 @@ module KafkaHandleEvent
     end
 
     def default_do_create
-      proxy.model_class.create(mapped_attributes)
+      if KafkaHandleEvent.config.adapter == :sequel
+        default_sequel_do_create
+      else
+        default_activerecord_do_create
+      end
     end
 
     def default_do_update
+      if KafkaHandleEvent.config.adapter == :sequel
+        default_sequel_do_update
+      else
+        default_activerecord_do_update
+      end
+    end
+
+    def default_sequel_do_create
+    end
+
+    def default_activerecord_do_create
+        proxy.model_class.create(mapped_attributes)
+    end
+
+    def default_sequel_do_update
+    end
+
+    def default_activerecord_do_update
       id = mapped_attributes[proxy.primaries[0]]
       record = proxy.model_class.find_or_initialize_by(id: id)
       record.attributes = mapped_attributes
@@ -48,6 +70,17 @@ module KafkaHandleEvent
     end
 
     def default_do_destroy
+      if KafkaHandleEvent.config.adapter == :sequel
+        default_sequel_do_destroy
+      else
+        default_activerecord_do_destroy
+      end
+    end
+
+    def default_sequel_do_destroy
+    end
+
+    def default_activerecord_do_destroy
       id = mapped_attributes[proxy.primaries[0]]
       record = proxy.model_class.find_by(id: id)
       record&.destroy

--- a/spec/kafka_handle_event/database_adapter_spec.rb
+++ b/spec/kafka_handle_event/database_adapter_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'kafka_handle_event/database_adapter'
+
+describe KafkaHandleEvent::DatabaseAdapter do
+  describe 'register' do
+    let(:default_create_block) { ->() {} }
+
+    it 'register new adapter' do
+      described_class.register(:custom_adapter, :create, default_create_block)
+      block = described_class.default_create_block(:custom_adapter)
+      expect(block).to eq(default_create_block)
+    end
+
+    describe 'default_update_block' do
+      let(:default_block) { ->() {} }
+      it 'returns correct block' do
+        described_class.register(:custom_adapter, :update, default_block)
+        block = described_class.default_update_block(:custom_adapter)
+        expect(block).to eq(default_block)
+      end
+    end
+
+    describe 'default_destroy_block' do
+      let(:default_block) { ->() {} }
+      it 'returns correct block' do
+        described_class.register(:custom_adapter, :destroy, default_block)
+        block = described_class.default_destroy_block(:custom_adapter)
+        expect(block).to eq(default_block)
+      end
+    end
+
+    context 'invalid method name' do
+      it 'raises erorr' do
+        expect {
+          described_class.register(:custom_adapter, :random_name, default_create_block)
+        }.to raise_error("Method name is not in create, update, destroy")
+      end
+    end
+  end
+end

--- a/spec/kafka_handle_event/event_handler_spec.rb
+++ b/spec/kafka_handle_event/event_handler_spec.rb
@@ -97,7 +97,11 @@ describe KafkaHandleEvent::EventHandler do
   end
 
   describe 'default on create block' do
-    let(:proxy) { KafkaHandleEvent::EventProxy.new(:member) }
+    let(:proxy) do
+      px = KafkaHandleEvent::EventProxy.new(:member)
+      px.primary_column(:id, :uuid)
+      px
+    end
     let(:create_message) do
       {
         'topic_type' => 'topic_name',
@@ -122,8 +126,10 @@ describe KafkaHandleEvent::EventHandler do
           config.adapter = :sequel
         end
       end
+
+      let(:default_block) { KafkaHandleEvent::DatabaseAdapter.default_create_block(:sequel) }
       it 'calls default sequel do create block' do
-        expect_any_instance_of(described_class).to receive(:default_sequel_do_create)
+        expect(default_block).to receive(:call)
         described_class.new(proxy, create_message).handle_event
       end
     end
@@ -131,18 +137,24 @@ describe KafkaHandleEvent::EventHandler do
     context 'adapter is activerecord' do
       before do
         KafkaHandleEvent.configure do |config|
-          config.adapter = :activerecord
+          config.adapter = :active_record
         end
       end
+      let(:default_block) { KafkaHandleEvent::DatabaseAdapter.default_create_block(:active_record) }
+
       it 'calls default activerecord do create block' do
-        expect_any_instance_of(described_class).to receive(:default_activerecord_do_create)
+        expect(default_block).to receive(:call)
         described_class.new(proxy, create_message).handle_event
       end
     end
   end
 
   describe 'default on update block' do
-    let(:proxy) { KafkaHandleEvent::EventProxy.new(:member) }
+    let(:proxy) do
+      px = KafkaHandleEvent::EventProxy.new(:member)
+      px.primary_column(:id, :uuid)
+      px
+    end
     let(:update_message) do
       {
         'topic_type' => 'topic_name',
@@ -167,8 +179,10 @@ describe KafkaHandleEvent::EventHandler do
           config.adapter = :sequel
         end
       end
+      let(:default_block) { KafkaHandleEvent::DatabaseAdapter.default_update_block(:sequel) }
+
       it 'calls default sequel do update block' do
-        expect_any_instance_of(described_class).to receive(:default_sequel_do_update)
+        expect(default_block).to receive(:call)
         described_class.new(proxy, update_message).handle_event
       end
     end
@@ -176,18 +190,24 @@ describe KafkaHandleEvent::EventHandler do
     context 'adapter is activerecord' do
       before do
         KafkaHandleEvent.configure do |config|
-          config.adapter = :activerecord
+          config.adapter = :active_record
         end
       end
+      let(:default_block) { KafkaHandleEvent::DatabaseAdapter.default_update_block(:active_record) }
+
       it 'calls default activerecord do update block' do
-        expect_any_instance_of(described_class).to receive(:default_activerecord_do_update)
+        expect(default_block).to receive(:call)
         described_class.new(proxy, update_message).handle_event
       end
     end
   end
 
   describe 'default on destroy block' do
-    let(:proxy) { KafkaHandleEvent::EventProxy.new(:member) }
+    let(:proxy) do
+      px = KafkaHandleEvent::EventProxy.new(:member)
+      px.primary_column(:id, :uuid)
+      px
+    end
     let(:destroy_message) do
       {
         'topic_type' => 'topic_name',
@@ -212,8 +232,10 @@ describe KafkaHandleEvent::EventHandler do
           config.adapter = :sequel
         end
       end
+      let(:default_block) { KafkaHandleEvent::DatabaseAdapter.default_destroy_block(:sequel) }
+
       it 'calls default sequel do destroy block' do
-        expect_any_instance_of(described_class).to receive(:default_sequel_do_destroy)
+        expect(default_block).to receive(:call)
         described_class.new(proxy, destroy_message).handle_event
       end
     end
@@ -221,11 +243,13 @@ describe KafkaHandleEvent::EventHandler do
     context 'adapter is activerecord' do
       before do
         KafkaHandleEvent.configure do |config|
-          config.adapter = :activerecord
+          config.adapter = :active_record
         end
       end
+      let(:default_block) { KafkaHandleEvent::DatabaseAdapter.default_destroy_block(:active_record) }
+
       it 'calls default activerecord do destroy block' do
-        expect_any_instance_of(described_class).to receive(:default_activerecord_do_destroy)
+        expect(default_block).to receive(:call)
         described_class.new(proxy, destroy_message).handle_event
       end
     end

--- a/spec/kafka_handle_event/event_handler_spec.rb
+++ b/spec/kafka_handle_event/event_handler_spec.rb
@@ -18,11 +18,10 @@ describe KafkaHandleEvent::EventHandler do
             'last_name' => 'bede',
             'avatar_url' => '/avartar.png',
             'email' => 'email@email.com',
-            'organisation_uuid' => 'organisation_uuid',
+            'organisation_uuid' => 'organisation_uuid'
           }
         }
       end
-
       context 'model is exist' do
         let(:proxy) { KafkaHandleEvent::EventProxy.new(:member) }
 
@@ -34,7 +33,7 @@ describe KafkaHandleEvent::EventHandler do
         end
 
         context 'provide custom do_create block' do
-          let(:custom_do_create) { -> (attrs) { p attrs } }
+          let(:custom_do_create) { ->(attrs) { p attrs } }
           before do
             proxy.do_create &custom_do_create
             proxy.primary_column :id, :uuid
@@ -50,7 +49,7 @@ describe KafkaHandleEvent::EventHandler do
       context 'model is not exist' do
         context 'provide custom do_create block' do
           let(:proxy) { KafkaHandleEvent::EventProxy.new(:randome) }
-          let(:custom_do_create) { -> (attrs) { p attrs } }
+          let(:custom_do_create) { ->(attrs) { p attrs } }
           before do
             proxy.do_create &custom_do_create
             proxy.primary_column :id, :uuid
@@ -65,23 +64,23 @@ describe KafkaHandleEvent::EventHandler do
 
         context 'does not provide do_create block' do
           let(:proxy) { KafkaHandleEvent::EventProxy.new(:randome) }
-          let(:custom_do_create) { -> (attrs) { p attrs } }
+          let(:custom_do_create) { ->(attrs) { p attrs } }
           before do
             proxy.primary_column :id, :uuid
           end
 
           it 'calls custom do_create block' do
             expect_any_instance_of(described_class).not_to receive(:default_do_create)
-            expect {
+            expect do
               described_class.new(proxy, create_message).handle_event
-            }.to raise_error('Need to setup do_create on model randome')
+            end.to raise_error('Need to setup do_create on model randome')
           end
         end
       end
 
       describe 'on_create' do
         let(:proxy) { KafkaHandleEvent::EventProxy.new(:member) }
-        let(:on_create_block) { -> (created_record, message) { } }
+        let(:on_create_block) { ->(created_record, message) {} }
         before do
           proxy.primary_column :id, :uuid
           proxy.on_create &on_create_block
@@ -93,6 +92,141 @@ describe KafkaHandleEvent::EventHandler do
           expect(on_create_block).to receive(:call).with(created_model, create_message)
           described_class.new(proxy, create_message).handle_event
         end
+      end
+    end
+  end
+
+  describe 'default on create block' do
+    let(:proxy) { KafkaHandleEvent::EventProxy.new(:member) }
+    let(:create_message) do
+      {
+        'topic_type' => 'topic_name',
+        'event' => 'create',
+        'uuid' => 'member_uuid',
+        'data' => {
+          'start_date' => '01/01/2016',
+          'date_of_birth' => '02/02/1990',
+          'active' => true,
+          'first_name' => 'Huy Vo',
+          'last_name' => 'bede',
+          'avatar_url' => '/avartar.png',
+          'email' => 'email@email.com',
+          'organisation_uuid' => 'organisation_uuid'
+        }
+      }
+    end
+
+    context 'adapter is sequel' do
+      before do
+        KafkaHandleEvent.configure do |config|
+          config.adapter = :sequel
+        end
+      end
+      it 'calls default sequel do create block' do
+        expect_any_instance_of(described_class).to receive(:default_sequel_do_create)
+        described_class.new(proxy, create_message).handle_event
+      end
+    end
+
+    context 'adapter is activerecord' do
+      before do
+        KafkaHandleEvent.configure do |config|
+          config.adapter = :activerecord
+        end
+      end
+      it 'calls default activerecord do create block' do
+        expect_any_instance_of(described_class).to receive(:default_activerecord_do_create)
+        described_class.new(proxy, create_message).handle_event
+      end
+    end
+  end
+
+  describe 'default on update block' do
+    let(:proxy) { KafkaHandleEvent::EventProxy.new(:member) }
+    let(:update_message) do
+      {
+        'topic_type' => 'topic_name',
+        'event' => 'update',
+        'uuid' => 'member_uuid',
+        'data' => {
+          'start_date' => '01/01/2016',
+          'date_of_birth' => '02/02/1990',
+          'active' => true,
+          'first_name' => 'Huy Vo',
+          'last_name' => 'bede',
+          'avatar_url' => '/avartar.png',
+          'email' => 'email@email.com',
+          'organisation_uuid' => 'organisation_uuid'
+        }
+      }
+    end
+
+    context 'adapter is sequel' do
+      before do
+        KafkaHandleEvent.configure do |config|
+          config.adapter = :sequel
+        end
+      end
+      it 'calls default sequel do update block' do
+        expect_any_instance_of(described_class).to receive(:default_sequel_do_update)
+        described_class.new(proxy, update_message).handle_event
+      end
+    end
+
+    context 'adapter is activerecord' do
+      before do
+        KafkaHandleEvent.configure do |config|
+          config.adapter = :activerecord
+        end
+      end
+      it 'calls default activerecord do update block' do
+        expect_any_instance_of(described_class).to receive(:default_activerecord_do_update)
+        described_class.new(proxy, update_message).handle_event
+      end
+    end
+  end
+
+  describe 'default on destroy block' do
+    let(:proxy) { KafkaHandleEvent::EventProxy.new(:member) }
+    let(:destroy_message) do
+      {
+        'topic_type' => 'topic_name',
+        'event' => 'destroy',
+        'uuid' => 'member_uuid',
+        'data' => {
+          'start_date' => '01/01/2016',
+          'date_of_birth' => '02/02/1990',
+          'active' => true,
+          'first_name' => 'Huy Vo',
+          'last_name' => 'bede',
+          'avatar_url' => '/avartar.png',
+          'email' => 'email@email.com',
+          'organisation_uuid' => 'organisation_uuid'
+        }
+      }
+    end
+
+    context 'adapter is sequel' do
+      before do
+        KafkaHandleEvent.configure do |config|
+          config.adapter = :sequel
+        end
+      end
+      it 'calls default sequel do destroy block' do
+        expect_any_instance_of(described_class).to receive(:default_sequel_do_destroy)
+        described_class.new(proxy, destroy_message).handle_event
+      end
+    end
+
+    context 'adapter is activerecord' do
+      before do
+        KafkaHandleEvent.configure do |config|
+          config.adapter = :activerecord
+        end
+      end
+      it 'calls default activerecord do destroy block' do
+        expect_any_instance_of(described_class).to receive(:default_activerecord_do_destroy)
+        described_class.new(proxy, destroy_message).handle_event
       end
     end
   end

--- a/spec/kafka_handle_event_spec.rb
+++ b/spec/kafka_handle_event_spec.rb
@@ -4,8 +4,11 @@ require 'kafka_handle_event/event_handler'
 
 describe KafkaHandleEvent do
   describe '#configure' do
-    it 'do somethings' do
-      expect(1).to eq(1)
+    described_class.configure do |config|
+      config.adapter= :sequel
+    end
+    it 'sets the adapter' do
+      expect(described_class.config.adapter).to eq(:sequel)
     end
   end
 

--- a/spec/kafka_handle_event_spec.rb
+++ b/spec/kafka_handle_event_spec.rb
@@ -4,8 +4,10 @@ require 'kafka_handle_event/event_handler'
 
 describe KafkaHandleEvent do
   describe '#configure' do
-    described_class.configure do |config|
-      config.adapter= :sequel
+    before do
+      described_class.configure do |config|
+        config.adapter= :sequel
+      end
     end
     it 'sets the adapter' do
       expect(described_class.config.adapter).to eq(:sequel)


### PR DESCRIPTION
# Summary
Currently, this gem only supports active record as model layer. But many microservices in EH are using `sinatra` + `sequel`. So I and @qhuyduong add the ability to support `Sequel` as well. I also refactor this gem to allow users to override default logic and add custom model layer.

# Changes in this PR
- Add `sequel` support
- Add `DatabaseAdapter` to manage all model adapter.