### PR TITLE
Duplicate pkey when a record is existing on create

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "kafka_handle_event",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "documents": [
     {
       "name": "README",

--- a/lib/kafka_handle_event/event_handler.rb
+++ b/lib/kafka_handle_event/event_handler.rb
@@ -36,9 +36,14 @@ module KafkaHandleEvent
     end
 
     def default_do_create
-      default_block = KafkaHandleEvent::DatabaseAdapter
-        .default_create_block(KafkaHandleEvent.config.adapter)
-      default_block.call(proxy.model_class, mapped_attributes)
+      id = mapped_attributes[proxy.primaries[0]]
+      if id.present?
+        default_do_update
+      else
+        default_block = KafkaHandleEvent::DatabaseAdapter
+          .default_create_block(KafkaHandleEvent.config.adapter)
+        default_block.call(proxy.model_class, mapped_attributes)
+      end
     end
 
     def default_do_update

--- a/spec/kafka_handle_event/event_handler_spec.rb
+++ b/spec/kafka_handle_event/event_handler_spec.rb
@@ -127,10 +127,26 @@ describe KafkaHandleEvent::EventHandler do
         end
       end
 
-      let(:default_block) { KafkaHandleEvent::DatabaseAdapter.default_create_block(:sequel) }
-      it 'calls default sequel do create block' do
-        expect(default_block).to receive(:call)
-        described_class.new(proxy, create_message).handle_event
+      context 'when a new record' do
+        let(:create_message_without_primary_value) do
+          create_message['uuid'] = nil
+          create_message
+        end
+        let(:default_block) { KafkaHandleEvent::DatabaseAdapter.default_create_block(:sequel) }
+
+        it 'calls default sequel do create block' do
+          expect(default_block).to receive(:call)
+          described_class.new(proxy, create_message_without_primary_value).handle_event
+        end
+      end
+
+      context 'when record is existing' do
+        let(:update_block) { KafkaHandleEvent::DatabaseAdapter.default_update_block(:sequel) }
+
+        it 'calls default sequel do update block' do
+          expect(update_block).to receive(:call)
+          described_class.new(proxy, create_message).handle_event
+        end
       end
     end
 
@@ -140,11 +156,27 @@ describe KafkaHandleEvent::EventHandler do
           config.adapter = :active_record
         end
       end
-      let(:default_block) { KafkaHandleEvent::DatabaseAdapter.default_create_block(:active_record) }
 
-      it 'calls default activerecord do create block' do
-        expect(default_block).to receive(:call)
-        described_class.new(proxy, create_message).handle_event
+      context 'with new record' do
+        let(:create_message_without_primary_value) do
+          create_message['uuid'] = nil
+          create_message
+        end
+        let(:default_block) { KafkaHandleEvent::DatabaseAdapter.default_create_block(:active_record) }
+
+        it 'calls default activerecord do create block' do
+          expect(default_block).to receive(:call)
+          described_class.new(proxy, create_message_without_primary_value).handle_event
+        end
+      end
+
+      context 'when record is existing' do
+        let(:update_block) { KafkaHandleEvent::DatabaseAdapter.default_update_block(:active_record) }
+
+        it 'calls default activerecord do update block' do
+          expect(update_block).to receive(:call)
+          described_class.new(proxy, create_message).handle_event
+        end
       end
     end
   end


### PR DESCRIPTION
# URL
#10 

# Summary
this issue will happen if the record is existing in DB and we are trying to migration data with `pkey`